### PR TITLE
feat: add authentication_policy field to app data sources

### DIFF
--- a/okta/services/idaas/data_source_okta_app.go
+++ b/okta/services/idaas/data_source_okta_app.go
@@ -74,6 +74,11 @@ func dataSourceApp() *schema.Resource {
 				Description: "Users associated with the application",
 				Deprecated:  "The `users` field is now deprecated for the data source `okta_app`, please replace all uses of this with: `okta_app_user_assignments`",
 			},
+			"authentication_policy": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "ID of the app's authentication policy",
+			},
 		}),
 		Description: "Get an application of any kind from Okta.",
 	}
@@ -125,5 +130,6 @@ func dataSourceAppRead(ctx context.Context, d *schema.ResourceData, meta interfa
 	_ = d.Set("status", app.Status)
 	p, _ := json.Marshal(app.Links)
 	_ = d.Set("links", string(p))
+	setAuthenticationPolicy(ctx, meta, d, app.Links)
 	return nil
 }

--- a/okta/services/idaas/data_source_okta_app_oauth.go
+++ b/okta/services/idaas/data_source_okta_app_oauth.go
@@ -154,6 +154,11 @@ func dataSourceAppOauth() *schema.Resource {
 				Computed:    true,
 				Description: "Indicates if the client is allowed to use wildcard matching of redirect_uris. Some valid values include: \"SUBDOMAIN\", \"DISABLED\".",
 			},
+			"authentication_policy": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "ID of the app's authentication policy",
+			},
 		}),
 		Description: "Get a OIDC application from Okta.",
 	}
@@ -249,6 +254,7 @@ func dataSourceAppOauthRead(ctx context.Context, d *schema.ResourceData, meta in
 	}
 	p, _ := json.Marshal(app.Links)
 	_ = d.Set("links", string(p))
+	setAuthenticationPolicy(ctx, meta, d, app.Links)
 	return nil
 }
 


### PR DESCRIPTION
## Summary
Adds `authentication_policy` field to `okta_app` and `okta_app_oauth` data sources to enable discovery of current app authentication policy associations.

## Problem
Currently, the app data sources only expose basic metadata (id, label, name, status) but cannot retrieve the `authentication_policy` field that exists in app resources. This limitation prevents users from building automated migration tooling for authentication policy changes.

## Solution
This change leverages the existing `setAuthenticationPolicy()` infrastructure used by app resources to extract the policy ID from the app's Links field returned by the Okta API.

## Changes
- Added `authentication_policy` schema field to both data sources
- Updated read functions to call `setAuthenticationPolicy()`
- No breaking changes - field is computed/optional

## Testing
- [x] Code compiles successfully with `go build`

The changes are minimal but enable automated authentication policy migration workflows. The implementation reuses existing infrastructure and should be ready for community review.

🤖 Generated with [Claude Code](https://claude.ai/code)